### PR TITLE
Remove duplication in the `wp:setup` tasks

### DIFF
--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -31,12 +31,13 @@ namespace :wp do
       set :wp_pass, password
     end
 
-    task :do_setup do
+    # Installs WordPress
+    task :install
       config = Config.new
-      # Install WordPress
       execute :wp, "core install --url='#{config.url}' --title='#{config.title}' --admin_user='#{config.user}' --admin_password='#{config.password}' --admin_email='#{config.email}' --path='wp'"
     end
 
+    # Prints report for the user
     task :report do
       config = Config.new
 
@@ -87,56 +88,48 @@ namespace :wp do
       invoke 'wp:set_permissions'
     end
 
-    desc "Setup WP on remote environment"
-    task :remote => ['wp:setup:generate_password'] do
+    # Installs WordPress and supporting files on remote server
+    task :remote_install => 'wp:setup:generate_password' do
       invoke 'deploy'
       invoke 'wp:setup:generate_remote_files'
+
+      set :wp_target_url, fetch(:stage_url)
+
       on roles(:web) do
-
         within release_path do
-          set :wp_target_url, fetch(:stage_url)
-          invoke 'wp:setup:do_setup'
-        end
-
-        if !fetch(:setup_all)
-          invoke 'wp:setup:report'
+          invoke 'wp:setup:install'
         end
       end
     end
 
-    desc "Setup WP on local environment"
-    task :local => ['wp:setup:generate_password'] do
+    # Installs WordPress and supporting files locally
+    task :local_install => 'wp:setup:generate_password' do
+      set :wp_target_url, fetch(:wp_localurl)
 
       if fetch(:vagrant_local)
         on roles(:dev) do |host|
           within fetch(:deploy_to) do
-            set :wp_target_url, fetch(:wp_localurl)
             invoke 'wp:setup:generate_local_files'
-            invoke 'wp:setup:do_setup'
+            invoke 'wp:setup:install'
           end
         end
-
       else
-
         run_locally do
-          set :wp_target_url, fetch(:wp_localurl)
           invoke 'wp:setup:generate_local_files'
-          invoke 'wp:setup:do_setup'
+          invoke 'wp:setup:install'
         end
-
       end
-
-      invoke 'wp:setup:report'
     end
+
+    desc "Setup WP on remote environment"
+    task :remote => ['wp:setup:remote_install', 'wp:setup:report']
+
+    desc "Setup WP on local environment"
+    task :local => ['wp:setup:local_install', 'wp:setup:report']
 
     desc "Setup WP on remote and local environments"
-    task :both => ['wp:setup:generate_password'] do
-      set :setup_all, true
+    task :both => ['wp:setup:remote_install', 'wp:setup:local_install', 'wp:setup:report']
 
-      # Setup remote and local envs
-      invoke "wp:setup:remote"
-      invoke "wp:setup:local"
-    end
   end
 
 end

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -12,6 +12,34 @@ namespace :wp do
 
   namespace :setup do
 
+    # Generates a random password and stores it as :wp_pass
+    task :generate_password do
+      o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
+      password = (0...18).map { o[rand(o.length)] }.join
+      set :wp_pass, password
+    end
+
+    task :do_setup do
+      # Get WP details from config in /config
+      title = fetch(:wp_sitename)
+      email = fetch(:wp_email)
+      user = fetch(:wp_user)
+      password = fetch(:wp_pass)
+      wp_siteurl = fetch(:wp_target_url)
+
+      # Install WordPress
+      execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}' --path='wp'"
+    end
+
+    # Create wp-config.php
+    task :create_wp_config do
+      database = YAML::load_file('config/database.yml')['local']
+      secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
+      db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
+      remote_config = false
+      File.open("wp-config.php", 'w') {|f| f.write(db_config) }
+    end
+
     desc "Generates wp-config.php on remote server"
     task :generate_remote_files do
       on roles(:web) do
@@ -37,36 +65,21 @@ namespace :wp do
     end
 
     desc "Setup WP on remote environment"
-    task :remote do
+    task :remote => ['wp:setup:generate_password'] do
       invoke 'deploy'
       invoke 'wp:setup:generate_remote_files'
       on roles(:web) do
-              
+
         within release_path do
-        
-          if !fetch(:setup_all)
-            # Generate a random password
-            o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
-            password = (0...18).map { o[rand(o.length)] }.join
-          else
-            password = fetch(:wp_pass)
-          end
-
-          # Get WP details from config in /config
-          wp_siteurl = fetch(:stage_url)
-          title = fetch(:wp_sitename)
-          email = fetch(:wp_email)
-          user = fetch(:wp_user)
-
-          # Install WordPress
-          execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}'"
+          set :wp_target_url, fetch(:stage_url)
+          invoke 'wp:setup:do_setup'
 
           if !fetch(:setup_all)
             puts <<-MSG
             \e[32m
             =========================================================================
               WordPress has successfully been installed. Here are your login details:
-              
+
               Username:       #{user}
               Password:       #{password}
               Email address:  #{email}
@@ -80,86 +93,45 @@ namespace :wp do
 
       end
     end
-    
+
     desc "Setup WP on local environment"
-    task :local do
+    task :local => ['wp:setup:generate_password'] do
 
       if fetch(:vagrant_local)
         on roles(:dev) do |host|
           within fetch(:deploy_to) do
+            set :wp_target_url, fetch(:wp_localurl)
+            invoke 'wp:setup:create_wp_config'
+            invoke 'wp:setup:do_setup'
 
-          if !fetch(:setup_all)
-            # Generate a random password
-            o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
-            password = (0...18).map { o[rand(o.length)] }.join
-          else
-            password = fetch(:wp_pass)
-          end
-          
-          # Get WP details from config in /config
-          title = fetch(:wp_sitename)
-          email = fetch(:wp_email)
-          user = fetch(:wp_user)
-          wp_siteurl = fetch(:wp_localurl)
+            puts <<-MSG
+            \e[32m
+            =========================================================================
+              WordPress has successfully been installed. Here are your login details:
 
-          # Create wp-config.php
-          database = YAML::load_file('config/database.yml')['local']
-          secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
-          db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
-          remote_config = false
-          File.open("wp-config.php", 'w') {|f| f.write(db_config) }
-
-          # Install WordPress
-          execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}' --path='wp'"
-
-          puts <<-MSG
-          \e[32m
-          =========================================================================
-            WordPress has successfully been installed. Here are your login details:
-            
-            Username:       #{user}
-            Password:       #{password}
-            Email address:  #{email}
-            Log in at:      #{wp_siteurl}/wp/wp-admin
-          =========================================================================
-          \e[0m
-          MSG
+              Username:       #{user}
+              Password:       #{password}
+              Email address:  #{email}
+              Log in at:      #{wp_siteurl}/wp/wp-admin
+            =========================================================================
+            \e[0m
+            MSG
 
           end
         end
-      
+
       else
-        
+
         run_locally do
-          if !fetch(:setup_all)
-            # Generate a random password
-            o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
-            password = (0...18).map { o[rand(o.length)] }.join
-          else
-            password = fetch(:wp_pass)
-          end
-          
-          # Get WP details from config in /config
-          title = fetch(:wp_sitename)
-          email = fetch(:wp_email)
-          user = fetch(:wp_user)
-          wp_siteurl = fetch(:wp_localurl)
-
-          # Create wp-config.php
-          database = YAML::load_file('config/database.yml')['local']
-          secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
-          db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
-          remote_config = false
-          File.open("wp-config.php", 'w') {|f| f.write(db_config) }
-
-          # Install WordPress
-          execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}' --path='wp'"
+          set :wp_target_url, fetch(:wp_localurl)
+          invoke 'wp:setup:create_wp_config'
+          invoke 'wp:setup:do_setup'
 
           puts <<-MSG
           \e[32m
           =========================================================================
             WordPress has successfully been installed. Here are your login details:
-            
+
             Username:       #{user}
             Password:       #{password}
             Email address:  #{email}
@@ -173,13 +145,8 @@ namespace :wp do
     end
 
     desc "Setup WP on remote and local environments"
-    task :both do
+    task :both => ['wp:setup:generate_password'] do
       set :setup_all, true
-
-      # Generate a random password
-      o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
-      password = (0...18).map { o[rand(o.length)] }.join
-      set :wp_pass, password
 
       # Setup remote and local envs
       invoke "wp:setup:remote"

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -57,11 +57,13 @@ namespace :wp do
 
     # Creates wp-config.php locally
     task :generate_local_files do
-      database = YAML::load_file('config/database.yml')['local']
-      secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
-      db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
-      remote_config = false
-      File.open("wp-config.php", 'w') {|f| f.write(db_config) }
+      on roles(:web) do
+        database = YAML::load_file('config/database.yml')['local']
+        secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
+        db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
+        remote_config = false
+        File.open("wp-config.php", 'w') {|f| f.write(db_config) }
+      end
     end
 
     desc "Generates wp-config.php on remote server"

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -1,3 +1,15 @@
+class Config
+  attr_reader :title, :email, :user, :password, :url
+  def initialize(options)
+    # Get WP details from config in /config
+    @title = fetch(:wp_sitename) || options.fetch(:title)
+    @email = fetch(:wp_email) || options.fetch(:email)
+    @user = fetch(:wp_user) || options.fetch(:user)
+    @password = fetch(:wp_pass) || options.fetch(:password)
+    @url = fetch(:wp_target_url) || options.fetch(:url)
+  end
+end
+
 namespace :wp do
 
   task :set_permissions do
@@ -20,19 +32,30 @@ namespace :wp do
     end
 
     task :do_setup do
-      # Get WP details from config in /config
-      title = fetch(:wp_sitename)
-      email = fetch(:wp_email)
-      user = fetch(:wp_user)
-      password = fetch(:wp_pass)
-      wp_siteurl = fetch(:wp_target_url)
-
+      config = Config.new
       # Install WordPress
-      execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}' --path='wp'"
+      execute :wp, "core install --url='#{config.url}' --title='#{config.title}' --admin_user='#{config.user}' --admin_password='#{config.password}' --admin_email='#{config.email}' --path='wp'"
     end
 
-    # Create wp-config.php
-    task :create_wp_config do
+    task :report do
+      config = Config.new
+
+      puts <<-MSG
+      \e[32m
+      =========================================================================
+        WordPress has successfully been installed. Here are your login details:
+
+        Username:       #{config.user}
+        Password:       #{config.password}
+        Email address:  #{config.email}
+        Log in at:      #{config.url}/wp/wp-admin
+      =========================================================================
+      \e[0m
+      MSG
+    end
+
+    # Creates wp-config.php locally
+    task :generate_local_files do
       database = YAML::load_file('config/database.yml')['local']
       secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
       db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
@@ -73,24 +96,11 @@ namespace :wp do
         within release_path do
           set :wp_target_url, fetch(:stage_url)
           invoke 'wp:setup:do_setup'
-
-          if !fetch(:setup_all)
-            puts <<-MSG
-            \e[32m
-            =========================================================================
-              WordPress has successfully been installed. Here are your login details:
-
-              Username:       #{user}
-              Password:       #{password}
-              Email address:  #{email}
-              Log in at:      #{wp_siteurl}/wp/wp-admin
-            =========================================================================
-            \e[0m
-            MSG
-          end
-
         end
 
+        if !fetch(:setup_all)
+          invoke 'wp:setup:report'
+        end
       end
     end
 
@@ -101,22 +111,8 @@ namespace :wp do
         on roles(:dev) do |host|
           within fetch(:deploy_to) do
             set :wp_target_url, fetch(:wp_localurl)
-            invoke 'wp:setup:create_wp_config'
+            invoke 'wp:setup:generate_local_files'
             invoke 'wp:setup:do_setup'
-
-            puts <<-MSG
-            \e[32m
-            =========================================================================
-              WordPress has successfully been installed. Here are your login details:
-
-              Username:       #{user}
-              Password:       #{password}
-              Email address:  #{email}
-              Log in at:      #{wp_siteurl}/wp/wp-admin
-            =========================================================================
-            \e[0m
-            MSG
-
           end
         end
 
@@ -124,24 +120,13 @@ namespace :wp do
 
         run_locally do
           set :wp_target_url, fetch(:wp_localurl)
-          invoke 'wp:setup:create_wp_config'
+          invoke 'wp:setup:generate_local_files'
           invoke 'wp:setup:do_setup'
-
-          puts <<-MSG
-          \e[32m
-          =========================================================================
-            WordPress has successfully been installed. Here are your login details:
-
-            Username:       #{user}
-            Password:       #{password}
-            Email address:  #{email}
-            Log in at:      #{wp_siteurl}/wp/wp-admin
-          =========================================================================
-          \e[0m
-          MSG
         end
 
       end
+
+      invoke 'wp:setup:report'
     end
 
     desc "Setup WP on remote and local environments"

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -32,7 +32,7 @@ namespace :wp do
     end
 
     # Installs WordPress
-    task :install
+    task :install do
       config = Config.new
       execute :wp, "core install --url='#{config.url}' --title='#{config.title}' --admin_user='#{config.user}' --admin_password='#{config.password}' --admin_email='#{config.email}' --path='wp'"
     end

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -1,12 +1,12 @@
 class Config
   attr_reader :title, :email, :user, :password, :url
-  def initialize(options)
+  def initialize
     # Get WP details from config in /config
-    @title = fetch(:wp_sitename) || options.fetch(:title)
-    @email = fetch(:wp_email) || options.fetch(:email)
-    @user = fetch(:wp_user) || options.fetch(:user)
-    @password = fetch(:wp_pass) || options.fetch(:password)
-    @url = fetch(:wp_target_url) || options.fetch(:url)
+    @title = fetch(:wp_sitename)
+    @email = fetch(:wp_email)
+    @user = fetch(:wp_user)
+    @password = fetch(:wp_pass)
+    @url = fetch(:wp_target_url)
   end
 end
 


### PR DESCRIPTION
@Vinsanity although I have installed `vvv` and `vv` and all the other `v`s, I still get "This doesn't seem to be a WordPress install`, so these tasks are untested and probably have bugs.

If anyone wants to help me get WP installed, I'd be happy to test. Otherwise, I'm happy to help debug whatever I've broken :)

Cheers!
